### PR TITLE
🎨 Palette: Add aria-pressed to recipe meal type toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-02-07 - [Toggle Button Accessibility]
+**Learning:** Visual toggle states (like `btn-primary` vs `btn-ghost`) are invisible to screen readers without programmatic state.
+**Action:** Always add `aria-pressed={condition}` to toggle buttons that don't change their label.

--- a/client/src/components/RecipeForm.tsx
+++ b/client/src/components/RecipeForm.tsx
@@ -107,6 +107,7 @@ export default function RecipeForm({ recipe, onSave, onCancel }: RecipeFormProps
                 type="button"
                 onClick={() => toggleSlot(slot)}
                 className={`btn btn-sm ${slotKeys.includes(slot) ? 'btn-primary' : 'btn-ghost'}`}
+                aria-pressed={slotKeys.includes(slot)}
               >
                 {slot}
               </button>

--- a/fix_recipe_form.py
+++ b/fix_recipe_form.py
@@ -1,0 +1,14 @@
+filepath = 'client/src/components/RecipeForm.tsx'
+with open(filepath, 'r') as f:
+    content = f.read()
+
+search_str = "className={`btn btn-sm ${slotKeys.includes(slot) ? 'btn-primary' : 'btn-ghost'}`}"
+replace_str = "className={`btn btn-sm ${slotKeys.includes(slot) ? 'btn-primary' : 'btn-ghost'}`}\n                aria-pressed={slotKeys.includes(slot)}"
+
+if search_str in content:
+    new_content = content.replace(search_str, replace_str)
+    with open(filepath, 'w') as f:
+        f.write(new_content)
+    print("Updated successfully")
+else:
+    print("String not found")


### PR DESCRIPTION
💡 What: Added `aria-pressed` attribute to meal type toggle buttons in RecipeForm.
🎯 Why: Screen reader users cannot perceive the visual state change (primary vs ghost button) without programmatic state.
♿ Accessibility: Improved toggle button accessibility for screen readers.

Also added a journal entry in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [15283133494146773031](https://jules.google.com/task/15283133494146773031) started by @joelmnz*